### PR TITLE
Added static to inline function to fix compile on Clang

### DIFF
--- a/main.c
+++ b/main.c
@@ -30,7 +30,7 @@
 
 #include "stuff.h"
 
-inline void write_u16_LE(u8 *dest, u16 val) {
+static inline void write_u16_LE(u8 *dest, u16 val) {
 	*dest++ = val & 0xFF;
 	*dest = val >> 8;
 	return;


### PR DESCRIPTION
C99 requires inline functions to only be used with inline calling. This was causing the an error when compiled without optimization enabled.

```
$ cc main.c
Undefined symbols for architecture x86_64:
  "_write_u16_LE", referenced from:
      _fixup_relocs in main-780408.o
      _fixup_seglut in main-780408.o
      _fixup_int3f in main-780408.o
ld: symbol(s) not found for architecture x86_64
```
See
https://clang.llvm.org/compatibility.html#inline
